### PR TITLE
Fix CSS alignment of social share buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gatsby-transformer-remark": "^2.8.37",
     "gh-pages": "^2.2.0",
     "jquery": "^3.4.1",
-    "node-sass": "^4.13.0",
+    "node-sass": "^4.14.1",
     "popper.js": "^1.15.0",
     "prismjs": "^1.21.0",
     "react": "^16.9.0",

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -30,7 +30,7 @@
 @media screen and (min-width: 768px) {
   .post-social-share-container {
     position: sticky;
-    top: 40%;
+    top: 60%;
   }
 }
 

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -27,6 +27,12 @@
 .post-social-share-container {
   grid-row-start: 2;
 }
+@media screen and (min-width: 768px) {
+  .post-social-share-container {
+    position: sticky;
+    top: 40%;
+  }
+}
 
 @media screen and (max-width: 768px) {
   .post-container {

--- a/src/components/Article_page/Sidebar.jsx
+++ b/src/components/Article_page/Sidebar.jsx
@@ -46,7 +46,8 @@ const Aside = styled.aside`
   display: grid;
   // grid-template-columns: 75%;
   grid-template-rows: 40px 80px;
-  margin: 14rem 0;
+  margin-top: 12rem;
+  margin-bottom: 1rem;
   .post-info-container {
     height: 100%;
     display: grid;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Mode from "../components/Mode";
-import { Link } from "gatsby";
 import Head from "../components/Head";
 import Layout from "../components/Layout";
 import styled from "styled-components";


### PR DESCRIPTION
**Solved Issue:** #3 

**Description:**
- Social button's won't overlap on desktop view.

![image](https://user-images.githubusercontent.com/35252877/136788382-b60c61a9-0d3c-4583-9c83-331d1e949f66.png)

- Social Icons fixed on scrolling blog content on desktop view.

